### PR TITLE
OGM-1585 fix flakiness in test due to undeterministic order of List

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
@@ -15,6 +15,7 @@ import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
 import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_REMOTE;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -151,14 +152,14 @@ public class PositionalParametersStoredProcedureCallTest extends OgmJpaTestCase 
 
 			List<?> listResult = storedProcedureQuery.getResultList();
 			assertThat( listResult ).hasSize( 2 );
-			if ( listResult.get( 0 ) instanceof Integer ) {
-				assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 );
-				assertThat( listResult.get( 1 ) ).isEqualTo( "title'2" );
-			}
-			else {
-				assertThat( listResult.get( 0 ) ).isEqualTo( "title'2" );
-				assertThat( ( (Number) listResult.get( 1 ) ).intValue() ).isEqualTo( 2 );
-			}
+			assertThat( listResult ).contains( "title'2" ) ;
+			List<Integer> found = new ArrayList<>();
+			listResult.forEach( obj -> {
+				if ( obj instanceof Number ) {
+					found.add( ( (Number) obj ).intValue() );
+				}
+			} );
+			assertThat( found ).containsExactly( 2 );
 		} );
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
@@ -151,8 +151,14 @@ public class PositionalParametersStoredProcedureCallTest extends OgmJpaTestCase 
 
 			List<?> listResult = storedProcedureQuery.getResultList();
 			assertThat( listResult ).hasSize( 2 );
-			assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 );
-			assertThat( listResult.get( 1 ) ).isEqualTo( "title'2" );
+			if ( listResult.get( 0 ) instanceof Integer ) {
+				assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 );
+				assertThat( listResult.get( 1 ) ).isEqualTo( "title'2" );
+			}
+			else {
+				assertThat( listResult.get( 0 ) ).isEqualTo( "title'2" );
+				assertThat( ( (Number) listResult.get( 1 ) ).intValue() ).isEqualTo( 2 );
+			}
 		} );
 	}
 


### PR DESCRIPTION
PositionalParametersStoredProcedureCallTest#testResultSetStaticCallRaw test was found to be flaky using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

Command used to run the test using NonDex:
`mvn -pl neo4j edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest#testResultSetStaticCallRaw`

The error log:
```
[INFO] Running org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest
2[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 4.294 s <<< FAILURE! - in org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest
3[ERROR] testResultSetStaticCallRaw(org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest)  Time elapsed: 3.902 s  <<< ERROR!
4java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
5               at org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest.lambda$testResultSetStaticCallRaw$5(PositionalParametersStoredProcedureCallTest.java:154)
6               at org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest.testResultSetStaticCallRaw(PositionalParametersStoredProcedureCallTest.java:145)
```


### Investigation       
The reason for the test's flakiness is that the List returned by `storedProcedureQuery.getResultList()` does not preserve the order of its elements. The test makes assumptions that the first element is Integer and the second is a String and hence does not check whether the correct objects are being class casted before using assertions.
```
assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 ); // assumes that the 1st element is an Integer
assertThat( listResult.get( 1 ) ).isEqualTo( "title'2" ); // Assumes that 2nd element is a string
```
 
### Fixes
To remove the ambiguity of the order of the List elements, the object type of the element in the list is checked to make sure that only Integer is being class casted to Number.
`listResult.get( 0 ) instanceof Integer`
This fix removes the possibility of ClassCastException and ensures that the flakiness is removed and the test passes.